### PR TITLE
Title: Add namespace to fix release build error with AGP 7+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,7 @@ apply plugin: 'com.android.library'
 
 apply from: "./resolve_dependencies.gradle"//解决编译导入Flutter相关的包报错问题
 android {
+    namespace 'com.imin.printer.imin_printer'
     compileSdkVersion 34
 
     compileOptions {


### PR DESCRIPTION
This change adds the required namespace to support AGP 7.0+ and allow successful release builds.